### PR TITLE
Makes GamePlatform Injectable

### DIFF
--- a/MonoGame.Framework/DefaultPlatformProvider.cs
+++ b/MonoGame.Framework/DefaultPlatformProvider.cs
@@ -1,0 +1,17 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+
+namespace Microsoft.Xna.Framework
+{
+  public class DefaultPlatformProvider : IPlatformProvider
+  {
+    public GamePlatform IPlatformProvider.CreatePlatform(Game game)
+    {
+      return GamePlatform.PlatformCreate(game);
+    }
+  }
+}

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -55,8 +55,10 @@ namespace Microsoft.Xna.Framework
 
 
         private bool _suppressDraw;
+
+        public Game() : this(new DefaultPlatformProvider()) { }
         
-        public Game()
+        public Game(IPlatformProvider platformProvider)
         {
             _instance = this;
 
@@ -65,7 +67,7 @@ namespace Microsoft.Xna.Framework
             _components = new GameComponentCollection();
             _content = new ContentManager(_services);
 
-            Platform = GamePlatform.PlatformCreate(this);
+            Platform = platformProvider.CreatePlatform(this);
             Platform.Activated += OnActivated;
             Platform.Deactivated += OnDeactivated;
             _services.AddService(typeof(GamePlatform), Platform);

--- a/MonoGame.Framework/IPlatformProvider.cs
+++ b/MonoGame.Framework/IPlatformProvider.cs
@@ -1,0 +1,14 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+
+namespace Microsoft.Xna.Framework
+{
+  public interface IPlatformProvider
+  {
+    GamePlatform CreatePlatform(Game game);
+  }
+}


### PR DESCRIPTION
Adds IPlatformProvider as an interface hook for providing an instance of
a GamePlatform (along with a default impl and updating Game to use it).

The hope is eventually this will allow for custom GamePlatform implementations, allowing games to be embedded in other contexts (such as a Winform Control).